### PR TITLE
Bypass Sansec server checks for CI

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -289,6 +289,7 @@ jobs:
       - name: Run eComscan
         env:
           ECOMSCAN_KEY: $${{ secrets.SANSEC_LICENSE_KEY }}
+          ECOMSCAN_SKIP_SERVER_CHECKS: 1
         run: |
           output=$(./ecomscan --no-auto-update --skip-database --deep --format=csv .)
           if [ -n "$output" ]; then


### PR DESCRIPTION
Add ECOMSCAN_SKIP_SERVER_CHECKS environment variable to Sansec scans across our repositories. This will stop it from throwing warnings for the GitHub runner environments themselves.

This should fix https://github.com/mage-os/github-actions/issues/352